### PR TITLE
Task/eliminate OnDestroy lifecycle hook from public pages

### DIFF
--- a/apps/client/src/app/pages/api/api-page.component.ts
+++ b/apps/client/src/app/pages/api/api-page.component.ts
@@ -14,9 +14,10 @@ import {
 
 import { CommonModule } from '@angular/common';
 import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
-import { Component, OnInit } from '@angular/core';
+import { Component, DestroyRef, OnInit } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { format, startOfYear } from 'date-fns';
-import { map, Observable, Subject, takeUntil } from 'rxjs';
+import { map, Observable } from 'rxjs';
 
 @Component({
   host: { class: 'page' },
@@ -35,9 +36,11 @@ export class GfApiPageComponent implements OnInit {
   public status$: Observable<DataProviderGhostfolioStatusResponse>;
 
   private apiKey: string;
-  private unsubscribeSubject = new Subject<void>();
 
-  public constructor(private http: HttpClient) {}
+  public constructor(
+    private destroyRef: DestroyRef,
+    private http: HttpClient
+  ) {}
 
   public ngOnInit() {
     this.apiKey = prompt($localize`Please enter your Ghostfolio API key:`);
@@ -51,18 +54,13 @@ export class GfApiPageComponent implements OnInit {
     this.status$ = this.fetchStatus();
   }
 
-  public ngOnDestroy() {
-    this.unsubscribeSubject.next();
-    this.unsubscribeSubject.complete();
-  }
-
   private fetchAssetProfile({ symbol }: { symbol: string }) {
     return this.http
       .get<DataProviderGhostfolioAssetProfileResponse>(
         `/api/v1/data-providers/ghostfolio/asset-profile/${symbol}`,
         { headers: this.getHeaders() }
       )
-      .pipe(takeUntil(this.unsubscribeSubject));
+      .pipe(takeUntilDestroyed(this.destroyRef));
   }
 
   private fetchDividends({ symbol }: { symbol: string }) {
@@ -82,7 +80,7 @@ export class GfApiPageComponent implements OnInit {
         map(({ dividends }) => {
           return dividends;
         }),
-        takeUntil(this.unsubscribeSubject)
+        takeUntilDestroyed(this.destroyRef)
       );
   }
 
@@ -103,7 +101,7 @@ export class GfApiPageComponent implements OnInit {
         map(({ historicalData }) => {
           return historicalData;
         }),
-        takeUntil(this.unsubscribeSubject)
+        takeUntilDestroyed(this.destroyRef)
       );
   }
 
@@ -129,7 +127,7 @@ export class GfApiPageComponent implements OnInit {
         map(({ items }) => {
           return items;
         }),
-        takeUntil(this.unsubscribeSubject)
+        takeUntilDestroyed(this.destroyRef)
       );
   }
 
@@ -145,7 +143,7 @@ export class GfApiPageComponent implements OnInit {
         map(({ quotes }) => {
           return quotes;
         }),
-        takeUntil(this.unsubscribeSubject)
+        takeUntilDestroyed(this.destroyRef)
       );
   }
 
@@ -155,7 +153,7 @@ export class GfApiPageComponent implements OnInit {
         '/api/v2/data-providers/ghostfolio/status',
         { headers: this.getHeaders() }
       )
-      .pipe(takeUntil(this.unsubscribeSubject));
+      .pipe(takeUntilDestroyed(this.destroyRef));
   }
 
   private getHeaders() {

--- a/apps/client/src/app/pages/faq/overview/faq-overview-page.component.ts
+++ b/apps/client/src/app/pages/faq/overview/faq-overview-page.component.ts
@@ -7,11 +7,11 @@ import {
   ChangeDetectorRef,
   Component,
   CUSTOM_ELEMENTS_SCHEMA,
-  OnDestroy
+  DestroyRef
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatCardModule } from '@angular/material/card';
 import { RouterModule } from '@angular/router';
-import { Subject, takeUntil } from 'rxjs';
 
 @Component({
   host: { class: 'page' },
@@ -21,21 +21,20 @@ import { Subject, takeUntil } from 'rxjs';
   styleUrls: ['./faq-overview-page.scss'],
   templateUrl: './faq-overview-page.html'
 })
-export class GfFaqOverviewPageComponent implements OnDestroy {
+export class GfFaqOverviewPageComponent {
   public pricingUrl = `https://ghostfol.io/${document.documentElement.lang}/${publicRoutes.pricing.path}`;
   public routerLinkFeatures = publicRoutes.features.routerLink;
   public user: User;
 
-  private unsubscribeSubject = new Subject<void>();
-
   public constructor(
     private changeDetectorRef: ChangeDetectorRef,
+    private destroyRef: DestroyRef,
     private userService: UserService
   ) {}
 
   public ngOnInit() {
     this.userService.stateChanged
-      .pipe(takeUntil(this.unsubscribeSubject))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((state) => {
         if (state?.user) {
           this.user = state.user;
@@ -43,10 +42,5 @@ export class GfFaqOverviewPageComponent implements OnDestroy {
           this.changeDetectorRef.markForCheck();
         }
       });
-  }
-
-  public ngOnDestroy() {
-    this.unsubscribeSubject.next();
-    this.unsubscribeSubject.complete();
   }
 }

--- a/apps/client/src/app/pages/faq/saas/saas-page.component.ts
+++ b/apps/client/src/app/pages/faq/saas/saas-page.component.ts
@@ -7,11 +7,11 @@ import {
   ChangeDetectorRef,
   Component,
   CUSTOM_ELEMENTS_SCHEMA,
-  OnDestroy
+  DestroyRef
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatCardModule } from '@angular/material/card';
 import { RouterModule } from '@angular/router';
-import { Subject, takeUntil } from 'rxjs';
 
 @Component({
   host: { class: 'page' },
@@ -21,7 +21,7 @@ import { Subject, takeUntil } from 'rxjs';
   styleUrls: ['./saas-page.scss'],
   templateUrl: './saas-page.html'
 })
-export class GfSaasPageComponent implements OnDestroy {
+export class GfSaasPageComponent {
   public pricingUrl = `https://ghostfol.io/${document.documentElement.lang}/${publicRoutes.pricing.path}`;
   public routerLinkAccount = internalRoutes.account.routerLink;
   public routerLinkAccountMembership =
@@ -30,16 +30,15 @@ export class GfSaasPageComponent implements OnDestroy {
   public routerLinkRegister = publicRoutes.register.routerLink;
   public user: User;
 
-  private unsubscribeSubject = new Subject<void>();
-
   public constructor(
     private changeDetectorRef: ChangeDetectorRef,
+    private destroyRef: DestroyRef,
     private userService: UserService
   ) {}
 
   public ngOnInit() {
     this.userService.stateChanged
-      .pipe(takeUntil(this.unsubscribeSubject))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((state) => {
         if (state?.user) {
           this.user = state.user;
@@ -47,10 +46,5 @@ export class GfSaasPageComponent implements OnDestroy {
           this.changeDetectorRef.markForCheck();
         }
       });
-  }
-
-  public ngOnDestroy() {
-    this.unsubscribeSubject.next();
-    this.unsubscribeSubject.complete();
   }
 }

--- a/apps/client/src/app/pages/markets/markets-page.component.ts
+++ b/apps/client/src/app/pages/markets/markets-page.component.ts
@@ -1,7 +1,6 @@
 import { GfHomeMarketComponent } from '@ghostfolio/client/components/home-market/home-market.component';
 
-import { Component, OnDestroy } from '@angular/core';
-import { Subject } from 'rxjs';
+import { Component } from '@angular/core';
 
 @Component({
   host: { class: 'page' },
@@ -10,11 +9,4 @@ import { Subject } from 'rxjs';
   styleUrls: ['./markets-page.scss'],
   templateUrl: './markets-page.html'
 })
-export class GfMarketsPageComponent implements OnDestroy {
-  private unsubscribeSubject = new Subject<void>();
-
-  public ngOnDestroy() {
-    this.unsubscribeSubject.next();
-    this.unsubscribeSubject.complete();
-  }
-}
+export class GfMarketsPageComponent {}

--- a/apps/client/src/app/pages/pricing/pricing-page.component.ts
+++ b/apps/client/src/app/pages/pricing/pricing-page.component.ts
@@ -12,9 +12,10 @@ import {
   ChangeDetectorRef,
   Component,
   CUSTOM_ELEMENTS_SCHEMA,
-  OnDestroy,
+  DestroyRef,
   OnInit
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatTooltipModule } from '@angular/material/tooltip';
@@ -27,8 +28,8 @@ import {
   informationCircleOutline
 } from 'ionicons/icons';
 import { StringValue } from 'ms';
-import { EMPTY, Subject } from 'rxjs';
-import { catchError, takeUntil } from 'rxjs/operators';
+import { EMPTY } from 'rxjs';
+import { catchError } from 'rxjs/operators';
 
 @Component({
   host: { class: 'page' },
@@ -46,7 +47,7 @@ import { catchError, takeUntil } from 'rxjs/operators';
   styleUrls: ['./pricing-page.scss'],
   templateUrl: './pricing-page.html'
 })
-export class GfPricingPageComponent implements OnDestroy, OnInit {
+export class GfPricingPageComponent implements OnInit {
   public baseCurrency: string;
   public coupon: number;
   public couponId: string;
@@ -92,11 +93,10 @@ export class GfPricingPageComponent implements OnDestroy, OnInit {
   public routerLinkRegister = publicRoutes.register.routerLink;
   public user: User;
 
-  private unsubscribeSubject = new Subject<void>();
-
   public constructor(
     private changeDetectorRef: ChangeDetectorRef,
     private dataService: DataService,
+    private destroyRef: DestroyRef,
     private notificationService: NotificationService,
     private userService: UserService
   ) {
@@ -124,7 +124,7 @@ export class GfPricingPageComponent implements OnDestroy, OnInit {
     this.price = subscriptionOffer?.price;
 
     this.userService.stateChanged
-      .pipe(takeUntil(this.unsubscribeSubject))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((state) => {
         if (state?.user) {
           this.user = state.user;
@@ -161,15 +161,11 @@ export class GfPricingPageComponent implements OnDestroy, OnInit {
 
           return EMPTY;
         }),
-        takeUntil(this.unsubscribeSubject)
+        takeUntilDestroyed(this.destroyRef)
       )
       .subscribe(({ sessionUrl }) => {
         window.location.href = sessionUrl;
       });
   }
 
-  public ngOnDestroy() {
-    this.unsubscribeSubject.next();
-    this.unsubscribeSubject.complete();
-  }
 }


### PR DESCRIPTION
## Summary

Eliminates the `OnDestroy` lifecycle hook and the `Subject`/`takeUntil` unsubscription pattern from 5 public page components, replacing it with Angular's modern `DestroyRef` + `takeUntilDestroyed` approach.

**Affected components:**
- `faq-overview-page` — replaces `Subject/takeUntil` with `DestroyRef/takeUntilDestroyed`
- `saas-page` — same
- `api-page` — same (across all 6 private fetch methods)
- `pricing-page` — same
- `markets-page` — removes unused `OnDestroy` + dead `Subject` entirely (no subscriptions existed)

Follows the pattern established in #6419 and #6527. Resolves the equivalent of ghostfolio/ghostfolio#6424 for these pages.

## Test plan

- [ ] Navigate to `/en/faq`, `/en/saas`, `/en/markets`, `/en/api`, `/en/pricing` — pages load correctly
- [ ] Log in/out while on these pages — user state updates render without errors
- [ ] Confirm no TypeScript compilation errors (`nx run client:build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sidsaw/ghostfolio/pull/1" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
